### PR TITLE
Prepended Global Handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ env-api
 main
 .tmp
 codeship.aes
+.vscode/
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Create a middleware handler. The purpose of the Handler is to keep Config and to
 middlewareHandler := rye.NewMWHandler(config)
 ```
 
+Set up any global handlers by using the `Use()` method. Global handlers get pre-pended to the list of your handlers for EVERY endpoint.
+They are bound to the MWHandler struct. Therefore, you could set up multiple MWHandler structs if you want to have different collections
+of global handlers.
+
+```go
+middlewareHandler.Use(middleware_routelogger)
+```
+
 Build your http handlers using the Handler type from the **rye** package.
 
 ```go
@@ -225,6 +233,14 @@ type MWHandler struct {
 #### Constructor
 ```go
 func NewMWHandler(statter statsd.Statter, statrate float32) *MWHandler
+```
+
+#### Use
+This method prepends a global handler for every Handle method you call.
+Use this multiple times to setup global handlers for every endpoint.
+Call `Use()` for each global handler before setting up additional routes.
+```go
+func (m *MWHandler) Use(handlers Handler)
 ```
 
 #### Handle

--- a/example/rye_example.go
+++ b/example/rye_example.go
@@ -25,6 +25,8 @@ func main() {
 
 	middlewareHandler := rye.NewMWHandler(config)
 
+	middlewareHandler.Use(beforeAllHandler)
+
 	routes := mux.NewRouter().StrictSlash(true)
 
 	routes.Handle("/", middlewareHandler.Handle([]rye.Handler{
@@ -69,6 +71,11 @@ func main() {
 	}
 
 	srv.ListenAndServe()
+}
+
+func beforeAllHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
+	log.Infof("This handler is called before every endpoint: %+v", r)
+	return nil
 }
 
 func homeHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {

--- a/example_overall_test.go
+++ b/example_overall_test.go
@@ -25,6 +25,8 @@ func Example_basic() {
 
 	middlewareHandler := rye.NewMWHandler(config)
 
+	middlewareHandler.Use(beforeAllHandler)
+
 	routes := mux.NewRouter().StrictSlash(true)
 
 	routes.Handle("/", middlewareHandler.Handle([]rye.Handler{
@@ -69,6 +71,11 @@ func Example_basic() {
 	}
 
 	srv.ListenAndServe()
+}
+
+func beforeAllHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
+	log.Infof("This handler is called before every endpoint: %+v", r)
+	return nil
 }
 
 func homeHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {

--- a/rye.go
+++ b/rye.go
@@ -20,7 +20,8 @@ import (
 
 // MWHandler struct is used to configure and access rye's basic functionality.
 type MWHandler struct {
-	Config Config
+	Config         Config
+	beforeHandlers []Handler
 }
 
 // Config struct allows you to set a reference to a statsd.Statter and include it's stats rate.
@@ -64,9 +65,16 @@ func NewMWHandler(config Config) *MWHandler {
 	}
 }
 
+// Use adds a handler to every request. All handlers set up with use
+// are fired first and then any route specific handlers are called
+func (m *MWHandler) Use(handler Handler) {
+	m.beforeHandlers = append(m.beforeHandlers, handler)
+}
+
 // The Handle function is the primary way to set up your chain of middlewares to be called by rye.
 // It returns a http.HandlerFunc from net/http that can be set as a route in your http server.
 func (m *MWHandler) Handle(handlers []Handler) http.Handler {
+	handlers = append(m.beforeHandlers, handlers...)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, handler := range handlers {
 			var resp *Response


### PR DESCRIPTION
This PR adds the ability to set up a bunch of handlers that get pre-pended to every Handler that you set up.
- `Use()` func bound to `MWHandler`
- `MWHandler` basically holds an ordered slice of global handlers
- On SETUP of a Handler, the two structs are joined together and then supplied to the closure
- README updated
- Tests updated and checked
- Examples updated and checked that they run
- Only 5 lines of code added to base library