### PR TITLE
Fix handle closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ main
 codeship.aes
 .vscode/
 .idea/
-
+debug
+debug.test

--- a/rye.go
+++ b/rye.go
@@ -74,8 +74,8 @@ func (m *MWHandler) Use(handler Handler) {
 // The Handle function is the primary way to set up your chain of middlewares to be called by rye.
 // It returns a http.HandlerFunc from net/http that can be set as a route in your http server.
 func (m *MWHandler) Handle(handlers []Handler) http.Handler {
-	handlers = append(m.beforeHandlers, handlers...)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers = append(m.beforeHandlers, handlers...)
 		for _, handler := range handlers {
 			var resp *Response
 


### PR DESCRIPTION
So, with the addition of the `Use()` functionality, a bug was discovered where the closure around `handlers` was being frozen at the last execution. The issue is about when the Handle function is called and initialized. 

The issue is described here (in number 5 in the blog post): http://keshavabharadwaj.com/2016/03/31/closure_golang/

After a few different approaches, the only solution here seems to be to add the handlers in the function. Basically, since these are function pointers, this is a very small and quick operation that shouldn't have material impact on performance. However, if performance is impacted and noticeable, we can take a different approach potentially regarding the adding of global handlers. 

The added test here `should execute before handlers and multiple Handles should manage their closure correctly` -> Confirms the problem. When run with the old code, both executions of `h` and `h2` end in only the `success2handler()` being called for both (so a total of twice). YUCK. With the 
```go
handlers = append(m.beforeHandlers, handlers...)
``` 
being INSIDE the return of the anonymous function, both `successHandler()` and `success2handler()` are called correctly.