### PR TITLE
Handle StatusCode with StopExecution

### DIFF
--- a/rye.go
+++ b/rye.go
@@ -99,8 +99,9 @@ func (m *MWHandler) do(w http.ResponseWriter, r *http.Request, handler Handler) 
 	func() {
 		statusCode := "2xx"
 		startTime := time.Now()
+		resp = handler(w, r)
 
-		if resp = handler(w, r); resp != nil {
+		if resp != nil {
 			func() {
 				// Stop execution if it's passed
 				if resp.StopExecution {
@@ -129,6 +130,10 @@ func (m *MWHandler) do(w http.ResponseWriter, r *http.Request, handler Handler) 
 				statusCode = strconv.Itoa(resp.StatusCode)
 				WriteJSONStatus(w, "error", resp.Error(), resp.StatusCode)
 			}()
+		}
+
+		if resp != nil && resp.StatusCode > 0 {
+			statusCode = strconv.Itoa(resp.StatusCode)
 		}
 
 		handlerName := getFuncName(handler)

--- a/rye.go
+++ b/rye.go
@@ -99,9 +99,8 @@ func (m *MWHandler) do(w http.ResponseWriter, r *http.Request, handler Handler) 
 	func() {
 		statusCode := "2xx"
 		startTime := time.Now()
-		resp = handler(w, r)
 
-		if resp != nil {
+		if resp = handler(w, r); resp != nil {
 			func() {
 				// Stop execution if it's passed
 				if resp.StopExecution {
@@ -127,13 +126,12 @@ func (m *MWHandler) do(w http.ResponseWriter, r *http.Request, handler Handler) 
 				}
 
 				// Write the error out
-				statusCode = strconv.Itoa(resp.StatusCode)
 				WriteJSONStatus(w, "error", resp.Error(), resp.StatusCode)
 			}()
-		}
 
-		if resp != nil && resp.StatusCode > 0 {
-			statusCode = strconv.Itoa(resp.StatusCode)
+			if resp.StatusCode > 0 {
+				statusCode = strconv.Itoa(resp.StatusCode)
+			}
 		}
 
 		handlerName := getFuncName(handler)

--- a/rye_test.go
+++ b/rye_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Rye", func() {
 				h := mwHandler.Handle([]Handler{stopExecutionWithStatusHandler, successHandler})
 				h.ServeHTTP(response, request)
 
-				Eventually(inc).Should(Receive(&statsInc{"handlers.stopExecutionWithStatusHandler.404", 1, float32(STATRATE)}))
+				Eventually(inc).Should(Receive(Equal(statsInc{"handlers.stopExecutionWithStatusHandler.404", 1, float32(STATRATE)})))
 				Expect(os.Getenv(RYE_TEST_HANDLER_ENV_VAR)).ToNot(Equal("1"))
 			})
 		})


### PR DESCRIPTION
This allows a `rye.Response` of this form to increment the correct counters in statsd:

```
&rye.Response{
  StopExecution: true,
  StatusCode: 404,
}
```

The status code will be reported to statsd as `404` whereas previously it would report as `2xx`.