### PR TITLE
Rename Sirupsen to sirupsen

### DIFF
--- a/example_overall_test.go
+++ b/example_overall_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/InVisionApp/rye"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/gorilla/mux"
 )

--- a/middleware_routelogger.go
+++ b/middleware_routelogger.go
@@ -3,7 +3,7 @@ package rye
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 /*

--- a/rye.go
+++ b/rye.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	//log "github.com/Sirupsen/logrus"
+	//log "github.com/sirupsen/logrus"
 	"github.com/cactus/go-statsd-client/statsd"
 )
 

--- a/rye_suite_test.go
+++ b/rye_suite_test.go
@@ -3,7 +3,7 @@ package rye
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Go won't tolerate two different capitalizations of that name. Latest new relic
uses the lower case one (which is what the main repo is also using). Conforming
to the new style.

Note: This will break all repos depending on it if they did not vendor.