### PR TITLE
[WIP] Add OpenTracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 A simple library to support http services. Currently, **rye** provides a middleware handler which can be used to chain http handlers together while providing statsd metrics for use with DataDog or other logging aggregators. In addition, **rye** comes with various pre-built middleware handlers for enabling functionality such as CORS and rate/CIDR limiting.
 
 ## Setup
-In order to use **rye**, you should vendor it and the **statsd** client within your project.
+In order to use **rye**, you should vendor it along with the **statsd** and **opentracing** clients within your project.
 
 ```sh 
 govendor fetch github.com/InVisionApp/rye
 govendor fetch github.com/cactus/go-statsd-client/statsd
+govendor fetch github.com/opentracing/opentracing-go
 ```
 
 ## Why another middleware lib?
@@ -44,6 +45,7 @@ Begin by importing the required libraries:
 ```go
 import (
     "github.com/cactus/go-statsd-client/statsd"
+    "github.com/opentracing/opentracing-go"
     "github.com/InVisionApp/rye"
 )
 ```
@@ -55,6 +57,11 @@ config := &rye.Config{
     Statter:  statsdClient,
     StatRate: DEFAULT_STATSD_RATE,
 }
+```
+
+(Optional) Configure your OpenTracing global handler. If not set it will default to a NoOp tracer:
+```go
+opentracing.SetGlobalTracer(tracer)
 ```
 
 Create a middleware handler. The purpose of the Handler is to keep Config and to provide an interface for chaining http handlers.

--- a/rye.go
+++ b/rye.go
@@ -13,6 +13,7 @@ import (
 
 	//log "github.com/Sirupsen/logrus"
 	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/opentracing/opentracing-go"
 )
 
 //go:generate counterfeiter -o fakes/statsdfakes/fake_statter.go $GOPATH/src/github.com/cactus/go-statsd-client/statsd/client.go Statter
@@ -75,6 +76,22 @@ func (m *MWHandler) Use(handler Handler) {
 // It returns a http.HandlerFunc from net/http that can be set as a route in your http server.
 func (m *MWHandler) Handle(customHandlers []Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Look for the request caller's SpanContext in the headers
+		// If not found create a new SpanContext
+		carrier := opentracing.HTTPHeadersCarrier(r.Header)
+		parentSpanContext, _ := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, carrier)
+
+		var span opentracing.Span
+		operationName := r.Method + " " + r.RequestURI
+		if parentSpanContext == nil {
+			span = opentracing.StartSpan(operationName)
+		} else {
+			span = opentracing.StartSpan(operationName, opentracing.ChildOf(parentSpanContext))
+		}
+		defer span.Finish()
+		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), span))
+
 		exit := false
 		for _, handler := range m.beforeHandlers {
 			exit, r = m.do(w, r, handler)


### PR DESCRIPTION
[WIP] This PR adds optional OpenTracing support to Rye. It follows a similar pattern to what was done for for `statsd` support. By default it will name the span using the request's method and URI (ie. GET /foo/bar).

Using Middlewares for OpenTracing was discarded because there isn't a way to enforce an "after Handler" to finalize the span. 