### PR TITLE
Adding custom statter option for clients to optionally use

### DIFF
--- a/middleware_static_filesystem_test.go
+++ b/middleware_static_filesystem_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Static File Middleware", func() {
 			It("should return a response", func() {
 				path = "/static-examples/dist/"
 
-				request, _ := http.NewRequest("GET", "/dist/test.html", nil)
+				request, _ = http.NewRequest("GET", "/dist/test.html", nil)
 
 				resp := NewStaticFilesystem(testPath+path, "/dist/")(response, request)
 				Expect(resp).To(BeNil())

--- a/rye.go
+++ b/rye.go
@@ -28,7 +28,7 @@ type MWHandler struct {
 // CustomStatter allows the client to log any additional statsD metrics Rye
 // computes around the request handler.
 type CustomStatter interface {
-	ReportStats(string, time.Duration, *http.Request, *Response) error
+	ReportStats(handlerName string, elapsedTime time.Duration, req *http.Request, resp *Response) error
 }
 
 // Config struct allows you to set a reference to a statsd.Statter and include it's stats rate.

--- a/rye.go
+++ b/rye.go
@@ -28,7 +28,7 @@ type MWHandler struct {
 // CustomStatter allows the client to log any additional statsD metrics Rye
 // computes around the request handler.
 type CustomStatter interface {
-	ReportStats(time.Duration, *http.Request, *Response) error
+	ReportStats(string, time.Duration, *http.Request, *Response) error
 }
 
 // Config struct allows you to set a reference to a statsd.Statter and include it's stats rate.
@@ -162,7 +162,7 @@ func (m *MWHandler) do(w http.ResponseWriter, r *http.Request, handler Handler) 
 		// If a CustomStatter is set, send the handler metrics to it.
 		// This allows the client to handle these metrics however it wants.
 		if m.Config.CustomStatter != nil && resp != nil {
-			go m.Config.CustomStatter.ReportStats(time.Since(startTime), r, resp)
+			go m.Config.CustomStatter.ReportStats(handlerName, time.Since(startTime), r, resp)
 		}
 	}()
 

--- a/rye_test.go
+++ b/rye_test.go
@@ -39,15 +39,16 @@ type statsTiming struct {
 var reportedStats = make(chan fakeReportedStats)
 
 type fakeReportedStats struct {
-	Duration time.Duration
-	Request  *http.Request
-	Response *Response
+	HandlerName string
+	Duration    time.Duration
+	Request     *http.Request
+	Response    *Response
 }
 
 type fakeCustomStatter struct{}
 
-func (fcs *fakeCustomStatter) ReportStats(dur time.Duration, req *http.Request, res *Response) error {
-	reportedStats <- fakeReportedStats{dur, req, res}
+func (fcs *fakeCustomStatter) ReportStats(handler string, dur time.Duration, req *http.Request, res *Response) error {
+	reportedStats <- fakeReportedStats{handler, dur, req, res}
 	return nil
 }
 
@@ -368,6 +369,7 @@ var _ = Describe("Rye", func() {
 				var resp *Response
 
 				Eventually(reportedStats).Should(Receive(&receivedReportedStats))
+				Expect(receivedReportedStats.HandlerName).To(Equal("successWithResponse"))
 				Expect(receivedReportedStats.Duration.Seconds()/1000 > 0).To(Equal(true))
 				Expect(receivedReportedStats.Request).To(BeAssignableToTypeOf(request))
 				Expect(receivedReportedStats.Response).To(BeAssignableToTypeOf(resp))
@@ -396,6 +398,7 @@ var _ = Describe("Rye", func() {
 
 				var receivedReportedStats fakeReportedStats
 
+				Expect(receivedReportedStats.HandlerName).To(Equal(""))
 				Expect(receivedReportedStats.Duration.Nanoseconds()).To(Equal(int64(0)))
 				Expect(receivedReportedStats.Request).To(BeNil())
 				Expect(receivedReportedStats.Response).To(BeNil())


### PR DESCRIPTION
The custom statter option will allow the client to receive all the metrics that Rye calculates around a request.  The custom statter must contain a ReportStats method which will then receive information around the request, response, as well as the duration of the request handler.  This is ideal for clients that would prefer to use the `datadog-go` library or any other library.  Additionally, this is a potential option to move the Rye middleware away from any kind of statsD reporting.